### PR TITLE
Feat add UUID converter

### DIFF
--- a/MySql/estructuras_tablas.sql
+++ b/MySql/estructuras_tablas.sql
@@ -1,3 +1,10 @@
+CREATE TABLE `provincias` (
+  `provincia_id` tinyint(3) unsigned NOT NULL,
+  `provincia` varchar(50) COLLATE utf8_spanish_ci NOT NULL,
+  PRIMARY KEY (`provincia_id`),
+  UNIQUE KEY `id_UNIQUE` (`provincia_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_spanish_ci;
+
 CREATE TABLE `municipios` (
   `provincia_id` tinyint(3) unsigned NOT NULL,
   `municipio_id` int(10) unsigned NOT NULL,
@@ -7,18 +14,11 @@ CREATE TABLE `municipios` (
   CONSTRAINT `provincia_id` FOREIGN KEY (`provincia_id`) REFERENCES `provincias` (`provincia_id`) ON DELETE NO ACTION ON UPDATE NO ACTION
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_spanish_ci;
 
-CREATE TABLE `provincias` (
-  `provincia_id` tinyint(3) unsigned NOT NULL,
-  `provincia` varchar(50) COLLATE utf8_spanish_ci NOT NULL,
-  PRIMARY KEY (`provincia_id`),
-  UNIQUE KEY `id_UNIQUE` (`provincia_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_spanish_ci;
-
 CREATE TABLE `sectores` (
   `municipio_id` int(10) unsigned NOT NULL,
   `sector_id` bigint(20) unsigned NOT NULL,
   `sector` varchar(150) COLLATE utf8_spanish_ci NOT NULL,
   PRIMARY KEY (`sector_id`),
-  KEY `ciudad_ir_idx` (`municipio_id`),
-  CONSTRAINT `ciudad_ir` FOREIGN KEY (`municipio_id`) REFERENCES `municipios` (`municipio_id`) ON DELETE NO ACTION ON UPDATE NO ACTION
+  KEY `municipio_id` (`municipio_id`),
+  CONSTRAINT `municipio_id` FOREIGN KEY (`municipio_id`) REFERENCES `municipios` (`municipio_id`) ON DELETE NO ACTION ON UPDATE NO ACTION
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_spanish_ci;

--- a/MySql/id_to_uuid.sql
+++ b/MySql/id_to_uuid.sql
@@ -1,0 +1,71 @@
+-- Se crea función para generar el UUID, en este caso UUIDv4.
+-- En caso de poseer una función customizada, solo tiene que remplazar esta.
+-- Función extraida de: https://stackoverflow.com/a/32965744/9510988
+DELIMITER //
+
+CREATE FUNCTION uuid_v4()
+    RETURNS CHAR(36) NO SQL
+BEGIN
+    -- Generate 8 2-byte strings that we will combine into a UUIDv4
+    SET @h1 = LPAD(HEX(FLOOR(RAND() * 0xffff)), 4, '0');
+    SET @h2 = LPAD(HEX(FLOOR(RAND() * 0xffff)), 4, '0');
+    SET @h3 = LPAD(HEX(FLOOR(RAND() * 0xffff)), 4, '0');
+    SET @h6 = LPAD(HEX(FLOOR(RAND() * 0xffff)), 4, '0');
+    SET @h7 = LPAD(HEX(FLOOR(RAND() * 0xffff)), 4, '0');
+    SET @h8 = LPAD(HEX(FLOOR(RAND() * 0xffff)), 4, '0');
+
+    -- 4th section will start with a 4 indicating the version
+    SET @h4 = CONCAT('4', LPAD(HEX(FLOOR(RAND() * 0x0fff)), 3, '0'));
+
+    -- 5th section first half-byte can only be 8, 9 A or B
+    SET @h5 = CONCAT(HEX(FLOOR(RAND() * 4 + 8)),
+                LPAD(HEX(FLOOR(RAND() * 0x0fff)), 3, '0'));
+
+    -- Build the complete UUID
+    RETURN LOWER(CONCAT(
+        @h1, @h2, '-', @h3, '-', @h4, '-', @h5, '-', @h6, @h7, @h8
+    ));
+END
+//
+-- Switch back the delimiter
+DELIMITER ;
+
+
+-- Agregar columnas UUID a cada tabla y renombrar las claves primarias
+ALTER TABLE provincias ADD COLUMN provincia_uuid UUID;
+ALTER TABLE municipios ADD COLUMN municipio_uuid UUID;
+ALTER TABLE sectores ADD COLUMN sector_uuid UUID;
+
+-- Generar UUIDs para cada fila existente
+UPDATE provincias SET provincia_uuid = uuid_v4();
+UPDATE municipios SET municipio_uuid = uuid_v4();
+UPDATE sectores SET sector_uuid = uuid_v4();
+
+-- Agregar nuevas columnas de clave foránea de UUID a las tablas municipios y sectores
+ALTER TABLE municipios ADD COLUMN provincia_uuid UUID;
+ALTER TABLE sectores ADD COLUMN municipio_uuid UUID;
+
+-- Actualizar las claves foráneas con los UUID correspondientes
+UPDATE municipios SET provincia_uuid = (SELECT provincia_uuid FROM provincias WHERE provincia_id = municipios.provincia_id);
+UPDATE sectores SET municipio_uuid = (SELECT municipio_uuid FROM municipios WHERE municipio_id = sectores.municipio_id);
+
+-- Una vez que las relaciones estén establecidas con UUIDs, puedes eliminar las antiguas columnas de clave foránea y cambiar las claves primarias
+-- Eliminar las viejas claves foráneas y primarias
+ALTER TABLE municipios DROP FOREIGN KEY provincia_id; 
+ALTER TABLE sectores DROP FOREIGN KEY municipio_id; 
+
+ALTER TABLE municipios DROP COLUMN provincia_id;
+ALTER TABLE sectores DROP COLUMN municipio_id;
+
+ALTER TABLE provincias DROP COLUMN provincia_id;
+ALTER TABLE municipios DROP COLUMN municipio_id;
+ALTER TABLE sectores DROP COLUMN sector_id;
+
+-- Cambiar las claves primarias
+ALTER TABLE provincias ADD PRIMARY KEY (provincia_uuid);
+ALTER TABLE municipios ADD PRIMARY KEY (municipio_uuid);
+ALTER TABLE sectores ADD PRIMARY KEY (sector_uuid);
+
+-- Establecer las nuevas claves foráneas para usar UUIDs
+ALTER TABLE municipios ADD CONSTRAINT fk_provincias FOREIGN KEY (provincia_uuid) REFERENCES provincias (provincia_uuid);
+ALTER TABLE sectores ADD CONSTRAINT fk_municipios FOREIGN KEY (municipio_uuid) REFERENCES municipios (municipio_uuid);

--- a/README.md
+++ b/README.md
@@ -4,17 +4,34 @@ Este proyecto provee Provincias, Municipios y Sectores de República Dominicana 
 ## 🧱 Estructura del repositorio
 * `JSON/`: contiene los documentos en formato JSON con los datos de las provincias, municipios y sectores. Útil para base de datos NoSQL, como [MongoDB](https://www.mongodb.com/).
 
-* `MySQL/`: contiene los archivos SQL necesarios para crear una base de datos en [MySQL](https://www.mysql.com/)/[MariaDB](https://mariadb.com/) de las provincias, municipios y sectores.
+* `MySql/`: contiene los archivos SQL necesarios para crear una base de datos en [MySQL](https://www.mysql.com/)/[MariaDB](https://mariadb.com/) de las provincias, municipios y sectores.
 
 ## 🗃️ Importación de la data
 ### MySQL/MariaDB
 ```shell
-cd MySQL/
+cd MySql/
 mysql -p -u root datos-rep-dom < estructuras_tablas.sql
 mysql -p -u root datos-rep-dom < provincias.sql.sql
 mysql -p -u root datos-rep-dom < municipios.sql
 mysql -p -u root datos-rep-dom < sectores.sql
 ```
+
+#### Utilizar UUID en lugar de un número entero como Primary Key
+Es posible que prefiera utilizar un [Universally Unique Identifier (UUID)](https://en.wikipedia.org/wiki/Universally_unique_identifier) en lugar de un número entero para no exponer los elementos de la Base de Datos. En ese caso, es posible mediante la utilización del script [`/MySql/id_to_uuid.sql`](/MySql/id_to_uuid.sql), el cual debe de ejecutarse luego de la importación de la data. El script modificará las columnas de la siguiente manera:
+
+| Nombre de la Columna (antiguo) | Nombre de la Columna (nuevo) | Tabla      |
+|--------------------------------|------------------------------|------------|
+| provincia_id                   | provincia_uuid               | provincias |
+| municipio_id                   | municipio_uuid               | municipios |
+| sector_id                      | sector_uuid                  | sectores   |
+
+De la misma forma, las llaves foráneas (Foreign Keys) serán renombradas de la siguiente manera.
+
+| Nombre de la Columna (antiguo) | Nombre de la Columna (nuevo) | Tabla      | Columna de referencia | Tabla de referencia |
+|--------------------------------|------------------------------|------------|-----------------------|---------------------|
+| provincia_id                   | provincia_uuid               | municipios | provincia_uuid        | provincias          |
+| municipio_id                   | municipio_uuid               | sectores   | municipio_uuid        | municipios          |
+
 
 ### MongoDB
 ```shell
@@ -22,4 +39,3 @@ cd JSON/
 mongoimport -d datos-rep-dom -c provincias provincias.json
 mongoimport -d datos-rep-dom -c municipios municipios.json
 mongoimport -d datos-rep-dom -c provincias sectores.json
-```


### PR DESCRIPTION
## Description
Use `UUID` Primary Keys instead of conventional `int` IDs. Until now the supported version of the standard is v4.

# TODO

- [x] Test changes
- [x] Add documentation
